### PR TITLE
Change: raw_reaction_add event to "schedule task"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ discord.py==1.6.0
 aiohttp==3.7.4.post0
 aioredis==1.3.1
 sentry-sdk==1.0.0
-aioredlock==0.7.0


### PR DESCRIPTION
I suggest replacing **on_raw_reaction_add** with a "schedule task" that will run once per minute. This will allow us to reduce the number of requests to the bot and, as a result, reduce the probability of race conditions.